### PR TITLE
FIX : Port

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,7 +1,7 @@
 import socket, threading, json
 s = socket.socket()
 host = "localhost"
-port = 8000
+port = 5000
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR,1)
 s.bind((host,port))
 s.listen(5)


### PR DESCRIPTION
When an app is always listening and waiting for interaction, is needly to listen on port 5000.

Changed port from 8000 to 5000, because why not?